### PR TITLE
fix: update typer to ^0.16.0 to fix Click compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 requests = "^2.32.3"
-typer = "^0.12.3"
+typer = "^0.16.0"
 pydantic = "^2.8.2"
 pyyaml = "^6.0.1"
 dotted-dict = "^1.1.3"


### PR DESCRIPTION
This PR updates typer to ^0.16.0 to resolve a make_metavar() compatibility error with click ≥ 8.2.